### PR TITLE
Bugfix

### DIFF
--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -57,8 +57,8 @@ export function merge(obj, src) {
     const res = obj;
     for (const key in src) {
         const clone = isMergeableObject(src[key]) ? cloneDeep(src[key]) : undefined;
-        const x = res[key];
-        if (clone && x && isMergeableObject(x)) {
+        let x;
+        if (clone && isMergeableObject((x = res[key]))) {
             merge(x, clone);
             continue;
         }

--- a/dist/umd/index.cjs
+++ b/dist/umd/index.cjs
@@ -95,8 +95,8 @@
         const res = obj;
         for (const key in src) {
             const clone = isMergeableObject(src[key]) ? cloneDeep(src[key]) : undefined;
-            const x = res[key];
-            if (clone && x && isMergeableObject(x)) {
+            let x;
+            if (clone && isMergeableObject((x = res[key]))) {
                 merge(x, clone);
                 continue;
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turtledash",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "turtledash",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turtledash",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tiny, efficient, TypeScript utility functions inspired by Lodash.",
   "main": "dist/umd/index.cjs",
   "module": "dist/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,9 +69,9 @@ export function merge <T extends object, U extends object> (obj: T, src: U): T &
   const res = obj as T & U
   for (const key in src) {
     const clone = isMergeableObject(src[key]) ? cloneDeep(src[key]) : undefined
-    const x = res[key]
-    if (clone && x && isMergeableObject(x)) {
-      merge(x, clone)
+    let x: (T & U)[Extract<keyof U, string>]
+    if (clone && isMergeableObject((x = res[key]))) {
+      merge(x as object, clone)
       continue
     }
     res[key] = clone || src[key]


### PR DESCRIPTION
`merge` shoud only try to access the property if needed, to prevent issues if the accessor should throw.